### PR TITLE
Remove lint step from publishing CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,26 +18,12 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  lint:
-    name: Lint the code
-    needs: set-commit-hash
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
-    - uses: ottofeller/github-actions/npm-run@main
-      with:
-        node-version: 16
-        command: npm run lint
-
   test:
     name: Test the code
     needs: set-commit-hash
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         ref: ${{ needs.set-commit-hash.outputs.commit_hash }}
@@ -48,7 +34,7 @@ jobs:
 
   publish-npm:
     name: Publish the release to NPM
-    needs: [set-commit-hash, lint, test]
+    needs: [set-commit-hash, test]
     runs-on: ubuntu-latest
     steps:
       - uses: ottofeller/github-actions/publish-npm@main

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Plugin utilized in ottofeller.com projects",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/_mocha --forbid-only -R progress -c tests/lib/rules/*.js"
+    "test": "mocha --forbid-only -R progress -c tests/lib/rules/*.js"
   },
   "dependencies": {
     "requireindex": "1.2.0"


### PR DESCRIPTION
eslint is not configured and thus the step won't ever be successful. In order to lint the code need to add eslint config and a linting script to package.json.